### PR TITLE
Set Javadoc source version to configured target version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
                 <version>3.1.1</version>
                 <configuration>
                     <additionalOptions>-html5</additionalOptions>
+                    <source>${maven.compiler.target}</source>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Trying to build the project with Java 9+ fails with the following error message because the Javadoc of Java 6 didn't support modules yet:

```
Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:jar (default) on project ecs-logging-core: MavenReportException: Error while generating Javadoc:
Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/6/docs/api/ are in the unnamed module.
```

Refs https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8212233

<details>
<summary>Build environment</summary>

```
# ./mvnw -v
Apache Maven 3.6.1 (d66c9c0b3152b2e69ee9bac180bb8fcc8e6af555; 2019-04-04T21:00:29+02:00)
Maven home: /Users/joschi/.m2/wrapper/dists/apache-maven-3.6.1-bin/38pn40mp89t5c94bjdbeod370m/apache-maven-3.6.1
Java version: 11.0.4, vendor: Azul Systems, Inc., runtime: /Users/joschi/.sdkman/candidates/java/11.0.4-zulu
Default locale: de_DE, platform encoding: UTF-8
OS name: "mac os x", version: "10.14.6", arch: "x86_64", family: "mac"
```
</details>

<details>
<summary>Complete build output</summary>

```
# ./mvnw -V -B -q install
Apache Maven 3.6.1 (d66c9c0b3152b2e69ee9bac180bb8fcc8e6af555; 2019-04-04T21:00:29+02:00)
Maven home: /Users/joschi/.m2/wrapper/dists/apache-maven-3.6.1-bin/38pn40mp89t5c94bjdbeod370m/apache-maven-3.6.1
Java version: 11.0.4, vendor: Azul Systems, Inc., runtime: /Users/joschi/.sdkman/candidates/java/11.0.4-zulu
Default locale: de_DE, platform encoding: UTF-8
OS name: "mac os x", version: "10.14.6", arch: "x86_64", family: "mac"
[ERROR] sourceFile /Users/joschi/src/LICENSE does not exist

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running co.elastic.logging.TimestampSerializerTest
2019-08-06T12:09:12.375Z
2019-08-06T12:09:12.379Z
2019-08-06T14:08:40.199Z
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.87 sec - in co.elastic.logging.TimestampSerializerTest

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:jar (default) on project ecs-logging-core: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/6/docs/api/ are in the unnamed module.
[ERROR]
[ERROR] Command line was: /Users/joschi/.sdkman/candidates/java/11.0.4-zulu/bin/javadoc @options @packages
[ERROR]
[ERROR] Refer to the generated Javadoc files in '/Users/joschi/src/java-ecs-logging/ecs-logging-core/target/apidocs' dir.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :ecs-logging-core
```
</details>