### PR TITLE
ci(jenkins): fix typo in the param name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
     string(name: 'MAVEN_CONFIG', defaultValue: '-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn', description: 'Additional maven options.')
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'test_ci', defaultValue: true, description: 'Enable test')
-    booleanParam(name: 'docs_ci', defaultValue: true, description: 'Enable docs')
+    booleanParam(name: 'doc_ci', defaultValue: true, description: 'Enable doc validation')
   }
 
   stages {


### PR DESCRIPTION
## Highlights
- Javadoc stage is not triggered as the params don't match with the when condition