### PR TITLE
Automatically activate IntelliJ profile in IntelliJ IDEA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,13 @@
             <id>IntelliJ</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
+                <!-- https://youtrack.jetbrains.com/issue/IDEA-85478 -->
+                <property>
+                    <name>idea.maven.embedder.version</name>
+                </property>
             </activation>
             <properties>
-                <maven.compiler.target>10</maven.compiler.target>
+                <maven.compiler.target>${maven.compiler.testTarget}</maven.compiler.target>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
By checking for the `idea.maven.embedder.version`, we can activate the "IntelliJ" profile automatically when the project is opened in IntelliJ IDEA.

Refs https://youtrack.jetbrains.com/issue/IDEA-85478