### PR TITLE
Serialize stack traces in error.stack_trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ We recommend using this library to log into a JSON log file and let Filebeat sen
 |ECS field | Log4j2 API  |
 |----------|-------------|
 |[`@timestamp`](https://www.elastic.co/guide/en/ecs/current/ecs-base.html) | [`LogEvent#getTimeMillis()`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getTimeMillis()) |
-| [`log.level`](https://www.elastic.co/guide/en/ecs/current/ecs-log.html) | [`LogEvent#getLevel()`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getLevel()) |
-|[`log.logger`](https://www.elastic.co/guide/en/ecs/current/ecs-log.html)|[`LogEvent#getLoggerName(`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getLoggerName())|
+|[`log.level`](https://www.elastic.co/guide/en/ecs/current/ecs-log.html) | [`LogEvent#getLevel()`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getLevel()) |
+|[`log.logger`](https://www.elastic.co/guide/en/ecs/current/ecs-log.html)|[`LogEvent#getLoggerName()`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getLoggerName())|
 |[`message`](https://www.elastic.co/guide/en/ecs/current/ecs-base.html)|[`LogEvent#getMessage()`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getMessage())|
-|[`message`](https://www.elastic.co/guide/en/ecs/current/ecs-base.html)|[`LogEvent#getThrown()`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getThrown())|
+|[`error.code`](https://www.elastic.co/guide/en/ecs/current/ecs-error.html)|[`Throwable#getClass()`](https://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#getClass())|
+|[`error.message`](https://www.elastic.co/guide/en/ecs/current/ecs-error.html)|[`Throwable#getStackTrace()`](https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#getMessage())|
+|[`error.stack_trace`](https://www.elastic.co/guide/en/ecs/current/ecs-error.html)|[`Throwable#getStackTrace()`](https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#getStackTrace())|
 |[`process.thread.name`](https://www.elastic.co/guide/en/ecs/current/ecs-process.html)|[`LogEvent#getThreadName()`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getThreadName()) |
 |[`labels`](https://www.elastic.co/guide/en/ecs/current/ecs-base.html)|[`LogEvent#getContextMap()`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getContextMap())|
 |[`tags`](https://www.elastic.co/guide/en/ecs/current/ecs-base.html)|[`LogEvent#getContextStack()`](https://logging.apache.org/log4j/log4j-2.3/log4j-core/apidocs/org/apache/logging/log4j/core/LogEvent.html#getContextStack())|

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Example:
 {"@timestamp":"2019-08-06T12:09:12.375Z", "log.level": "INFO", "message":"Tomcat started on port(s): 8080 (http) with context path ''", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.boot.web.embedded.tomcat.TomcatWebServer"}
 {"@timestamp":"2019-08-06T12:09:12.379Z", "log.level": "INFO", "message":"Started PetClinicApplication in 7.095 seconds (JVM running for 9.082)", "service.name":"spring-petclinic","process.thread.name":"restartedMain","log.logger":"org.springframework.samples.petclinic.PetClinicApplication"}
 {"@timestamp":"2019-08-06T14:08:40.199Z", "log.level":"DEBUG", "message":"init find form", "service.name":"spring-petclinic","process.thread.name":"http-nio-8080-exec-8","log.logger":"org.springframework.samples.petclinic.owner.OwnerController","transaction.id":"28b7fb8d5aba51f1","trace.id":"2869b25b5469590610fea49ac04af7da"}
+{"@timestamp":"2019-09-17T13:16:48.038Z", "log.level":"ERROR", "message":"Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.RuntimeException: Expected: controller used to showcase what happens when an exception is thrown] with root cause", "process.thread.name":"http-nio-8080-exec-1","log.logger":"org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/].[dispatcherServlet]","log.origin":{"file":"DirectJDKLog.java","function":"log","line":175},"error.code":"java.lang.RuntimeException","error.message":"Expected: controller used to showcase what happens when an exception is thrown","error.stack_trace":[
+	"java.lang.RuntimeException: Expected: controller used to showcase what happens when an exception is thrown",
+	"\tat org.springframework.samples.petclinic.system.CrashController.triggerException(CrashController.java:33)",
+	"\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)",
+	"\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)",
+	"\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)",
+	"\tat java.lang.reflect.Method.invoke(Method.java:498)",
+	"\tat org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)",
+	"\tat java.lang.Thread.run(Thread.java:748)"]}
 ```
 
 ## Why ECS logging?
@@ -32,6 +41,7 @@ Example:
   The log4j2 `EcsLayout` does not allocate any memory (unless the log event contains an `Exception`)
 * Decently human-readable JSON structure \
   The first three fields are always `@timestamp`, `log.level` and `message`.
+  It's also possible to format stack traces so that each element is rendered in a new line.
 * Use the Kibana [Logs UI](https://www.elastic.co/guide/en/kibana/7.3/xpack-logs.html) without additional configuration \
   As this library adheres to [ECS](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html), the Logs UI knows which fields to show
 * Out-of-the-box correlation of logs and traces via the Logs UI and APM UI when using the [Elastic APM Java agent](https://www.elastic.co/guide/en/apm/agent/java/current/index.html)

--- a/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
@@ -25,7 +25,7 @@
 package co.elastic.logging;
 
 import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +35,8 @@ public class EcsJsonSerializer {
 
     public static final List<String> DEFAULT_TOP_LEVEL_LABELS = Arrays.asList("trace.id", "transaction.id", "span.id", "error.id", "service.name");
     private static final TimestampSerializer TIMESTAMP_SERIALIZER = new TimestampSerializer();
+    private static final ThreadLocal<StringBuilder> messageStringBuilder = new ThreadLocal<StringBuilder>();
+    private static final  String NEW_LINE = System.getProperty("line.separator");
 
     public static CharSequence toNullSafeString(final CharSequence s) {
         return s == null ? "" : s;
@@ -48,8 +50,7 @@ public class EcsJsonSerializer {
     }
 
     public static void serializeObjectEnd(StringBuilder builder) {
-        // last char is always a comma (,)
-        builder.setLength(builder.length() - 1);
+        removeIfEndsWith(builder, ",");
         builder.append('}');
         builder.append('\n');
     }
@@ -68,13 +69,9 @@ public class EcsJsonSerializer {
         }
     }
 
-    public static void serializeFormattedMessage(StringBuilder builder, String message, Throwable t) {
+    public static void serializeFormattedMessage(StringBuilder builder, String message) {
         builder.append("\"message\":\"");
         JsonUtils.quoteAsString(message, builder);
-        if (t != null) {
-            builder.append("\\n");
-            JsonUtils.quoteAsString(formatThrowable(t), builder);
-        }
         builder.append("\", ");
     }
 
@@ -138,22 +135,162 @@ public class EcsJsonSerializer {
         }
     }
 
-    public static void serializeException(StringBuilder builder, Throwable thrown) {
+    public static void serializeException(StringBuilder builder, Throwable thrown, boolean stackTraceAsArray) {
         if (thrown != null) {
             builder.append("\"error.code\":\"");
             JsonUtils.quoteAsString(thrown.getClass().getName(), builder);
             builder.append("\",");
             builder.append("\"error.message\":\"");
-            JsonUtils.quoteAsString(formatThrowable(thrown), builder);
+            JsonUtils.quoteAsString(thrown.getMessage(), builder);
             builder.append("\",");
+            if (stackTraceAsArray) {
+                builder.append("\"error.stack_trace\":[").append(NEW_LINE);
+                formatThrowableAsArray(builder, thrown);
+                builder.append(NEW_LINE).append("]");
+            } else {
+                builder.append("\"error.stack_trace\":\"");
+                JsonUtils.quoteAsString(formatThrowable(thrown), builder);
+                builder.append("\"");
+            }
         }
     }
 
+    public static void serializeException(StringBuilder builder, String exceptionClassName, String exceptionMessage, String stackTrace, boolean stackTraceAsArray) {
+        builder.append("\"error.code\":\"");
+        JsonUtils.quoteAsString(exceptionClassName, builder);
+        builder.append("\",");
+        builder.append("\"error.message\":\"");
+        JsonUtils.quoteAsString(exceptionMessage, builder);
+        builder.append("\",");
+        if (stackTraceAsArray) {
+            builder.append("\"error.stack_trace\":[").append(NEW_LINE);
+            for (String line : stackTrace.split("\\n")) {
+                appendQuoted(builder, line);
+            }
+            builder.append(NEW_LINE).append("]");
+        } else {
+            builder.append("\"error.stack_trace\":\"");
+            JsonUtils.quoteAsString(stackTrace, builder);
+            builder.append("\"");
+        }
+    }
+
+    private static void appendQuoted(StringBuilder builder, CharSequence content) {
+        builder.append('"');
+        JsonUtils.quoteAsString(content, builder);
+        builder.append('"');
+    }
+
     private static CharSequence formatThrowable(final Throwable throwable) {
-        StringWriter sw = new StringWriter(2048);
-        final PrintWriter pw = new PrintWriter(sw);
+        StringBuilder buffer = getMessageStringBuilder();
+        final PrintWriter pw = new PrintWriter(new StringBuilderWriter(buffer));
         throwable.printStackTrace(pw);
         pw.flush();
-        return sw.toString();
+        return buffer;
+    }
+
+    private static void formatThrowableAsArray(final StringBuilder jsonBuilder, final Throwable throwable) {
+        final StringBuilder buffer = getMessageStringBuilder();
+        final PrintWriter pw = new PrintWriter(new StringBuilderWriter(buffer), true) {
+            @Override
+            public void println() {
+                flush();
+                jsonBuilder.append("\t\"");
+                JsonUtils.quoteAsString(buffer, jsonBuilder);
+                jsonBuilder.append("\",");
+                jsonBuilder.append(NEW_LINE);
+                buffer.setLength(0);
+            }
+        };
+        throwable.printStackTrace(pw);
+        removeIfEndsWith(jsonBuilder, NEW_LINE);
+        removeIfEndsWith(jsonBuilder, ",");
+    }
+
+    public static void removeIfEndsWith(StringBuilder sb, String ending) {
+        if (endsWith(sb, ending)) {
+            sb.setLength(sb.length() - ending.length());
+        }
+    }
+
+    public static boolean endsWith(StringBuilder sb, String ending) {
+        int endingLength = ending.length();
+        int startIndex = sb.length() - endingLength;
+        if (startIndex < 0) {
+            return false;
+        }
+        for (int i = 0; i < endingLength; i++) {
+            if (sb.charAt(startIndex + i) != ending.charAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static StringBuilder getMessageStringBuilder() {
+        StringBuilder result = messageStringBuilder.get();
+        if (result == null) {
+            result = new StringBuilder(1024);
+            messageStringBuilder.set(result);
+        }
+        result.setLength(0);
+        return result;
+    }
+
+    private static class StringBuilderWriter extends Writer {
+
+        private final StringBuilder buffer;
+
+        StringBuilderWriter(StringBuilder buffer) {
+            this.buffer = buffer;
+        }
+
+        @Override
+        public Writer append(CharSequence csq) {
+            buffer.append(csq);
+            return this;
+        }
+
+        @Override
+        public void write(String str) {
+            buffer.append(str);
+        }
+
+        @Override
+        public void write(String str, int off, int len) {
+            buffer.append(str, off, len);
+        }
+
+        @Override
+        public Writer append(CharSequence csq, int start, int end) {
+            buffer.append(csq, start, end);
+            return this;
+        }
+
+        @Override
+        public Writer append(char c) {
+            buffer.append(c);
+            return this;
+        }
+
+        @Override
+        public void write(int c) {
+            buffer.append((char) c);
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) {
+            buffer.append(cbuf, off, len);
+        }
+
+        @Override
+        public void flush() {
+
+        }
+
+        @Override
+        public void close() {
+
+        }
     }
 }

--- a/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
@@ -146,7 +146,7 @@ public class EcsJsonSerializer {
             if (stackTraceAsArray) {
                 builder.append("\"error.stack_trace\":[").append(NEW_LINE);
                 formatThrowableAsArray(builder, thrown);
-                builder.append(NEW_LINE).append("]");
+                builder.append("]");
             } else {
                 builder.append("\"error.stack_trace\":\"");
                 JsonUtils.quoteAsString(formatThrowable(thrown), builder);
@@ -167,7 +167,7 @@ public class EcsJsonSerializer {
             for (String line : stackTrace.split("\\n")) {
                 appendQuoted(builder, line);
             }
-            builder.append(NEW_LINE).append("]");
+            builder.append("]");
         } else {
             builder.append("\"error.stack_trace\":\"");
             JsonUtils.quoteAsString(stackTrace, builder);

--- a/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
@@ -1,0 +1,89 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.logging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EcsJsonSerializerTest {
+
+    @Test
+    void serializeExceptionAsString() throws IOException {
+        Exception exception = new Exception("foo");
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append('{');
+        EcsJsonSerializer.serializeException(jsonBuilder, exception, false);
+        jsonBuilder.append('}');
+        JsonNode jsonNode = new ObjectMapper().readTree(jsonBuilder.toString());
+
+        assertThat(jsonNode.get("error.code").textValue()).isEqualTo(exception.getClass().getName());
+        assertThat(jsonNode.get("error.message").textValue()).isEqualTo("foo");
+        StringWriter stringWriter = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stringWriter));
+        assertThat(jsonNode.get("error.stack_trace").textValue()).isEqualTo(stringWriter.toString());
+    }
+
+    @Test
+    void serializeExceptionAsArray() throws IOException {
+        Exception exception = new Exception("foo");
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append('{');
+        EcsJsonSerializer.serializeException(jsonBuilder, exception, true);
+        jsonBuilder.append('}');
+        System.out.println(jsonBuilder);
+        JsonNode jsonNode = new ObjectMapper().readTree(jsonBuilder.toString());
+
+        assertThat(jsonNode.get("error.code").textValue()).isEqualTo(exception.getClass().getName());
+        assertThat(jsonNode.get("error.message").textValue()).isEqualTo("foo");
+        StringWriter stringWriter = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stringWriter));
+        assertThat(StreamSupport.stream(jsonNode.get("error.stack_trace").spliterator(), false)
+                .map(JsonNode::textValue)
+                .collect(Collectors.joining("\n", "", "\n")))
+                .isEqualTo(stringWriter.toString());
+    }
+
+    @Test
+    void testRemoveIfEndsWith() {
+        assertRemoveIfEndsWith("", "foo", "");
+        assertRemoveIfEndsWith("foobar", "foo", "foobar");
+        assertRemoveIfEndsWith("barfoo", "foo", "bar");
+    }
+
+    private void assertRemoveIfEndsWith(String builder, String ending, String expected) {
+        StringBuilder sb = new StringBuilder(builder);
+        EcsJsonSerializer.removeIfEndsWith(sb, ending);
+        assertThat(sb.toString()).isEqualTo(expected);
+    }
+}

--- a/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
+++ b/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
@@ -53,6 +53,7 @@ class Log4jEcsLayoutTest extends AbstractEcsLoggingTest {
         logger.addAppender(appender);
         ecsLayout = new EcsLayout();
         ecsLayout.setServiceName("test");
+        ecsLayout.setStackTraceAsArray(true);
     }
 
     @BeforeEach

--- a/log4j2-ecs-layout/README.md
+++ b/log4j2-ecs-layout/README.md
@@ -46,7 +46,7 @@ Instead of the usual `<PatternLayout/>`, use `<EcsLayout serviceName="my-app"/>`
 |-----------------|-------|-------|-----------|
 |serviceName      |String |       |Sets the `service.name` field so you can filter your logs by a particular service |
 |includeMarkers   |boolean|`false`|Log [Markers](https://logging.apache.org/log4j/2.0/manual/markers.html) as `tags` |
-|stackTraceAsArray|boolean|`false`|Serializes the `error.stack_trace` as a JSON array where each element is in a new line to improve readability. Note that this requires a slightly more complex Filebeat setup. See also https://github.com/elastic/java-ecs-logging/blob/master/README.md#TODO|
+|stackTraceAsArray|boolean|`false`|Serializes the `error.stack_trace` as a JSON array where each element is in a new line to improve readability. Note that this requires a slightly more complex [Filebeat configuration](../README.md#when-stacktraceasarray-is-enabled).|
 
 To include any custom field in the output, use following syntax:
 

--- a/log4j2-ecs-layout/README.md
+++ b/log4j2-ecs-layout/README.md
@@ -19,13 +19,6 @@ Add a dependency to your application
 
 Instead of the usual `<PatternLayout/>`, use `<EcsLayout serviceName="my-app"/>`.
 
-If you want to include [Markers](https://logging.apache.org/log4j/2.0/manual/markers.html) as tags,
-set the `includeMarkers` attribute to `true` (default: `false`).
-
-```
-<EcsLayout serviceName="my-app" includeMarkers="true"/>
-```
-
 ## Example
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -47,6 +40,24 @@ set the `includeMarkers` attribute to `true` (default: `false`).
 </Configuration>
 ```
 
+## Layout Parameters
+
+|Parameter name   |Type   |Default|Description|
+|-----------------|-------|-------|-----------|
+|serviceName      |String |       |Sets the `service.name` field so you can filter your logs by a particular service |
+|includeMarkers   |boolean|`false`|Log [Markers](https://logging.apache.org/log4j/2.0/manual/markers.html) as `tags` |
+|stackTraceAsArray|boolean|`false`|Serializes the `error.stack_trace` as a JSON array where each element is in a new line to improve readability. Note that this requires a slightly more complex Filebeat setup. See also https://github.com/elastic/java-ecs-logging/blob/master/README.md#TODO|
+
+To include any custom field in the output, use following syntax:
+
+```xml
+  <EcsLayout>
+    <KeyValuePair key="additionalField1" value="constant value"/>
+    <KeyValuePair key="additionalField2" value="$${ctx:key}"/>
+  </EcsLayout>
+```
+
+Custom fields are included in the order they are declared. The values support [lookups](https://logging.apache.org/log4j/2.x/manual/lookups.html).
 ## Structured logging
 
 By leveraging log4j2's `MapMessage` or even by implementing your own `MultiformatMessage` with JSON support,

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
@@ -68,6 +68,7 @@ class Log4j2EcsLayoutTest extends AbstractLog4j2EcsLayoutTest {
                 .setConfiguration(ctx.getConfiguration())
                 .setServiceName("test")
                 .setIncludeMarkers(true)
+                .setStackTraceAsArray(true)
                 .setAdditionalFields(new KeyValuePair[]{
                         new KeyValuePair("cluster.uuid", "9fe9134b-20b0-465e-acf9-8cc09ac9053b"),
                         new KeyValuePair("node.id", "${node.id}"),

--- a/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
+++ b/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
@@ -5,7 +5,7 @@
     </Properties>
     <Appenders>
         <List name="TestAppender">
-            <EcsLayout serviceName="test" includeMarkers="true">
+            <EcsLayout serviceName="test" includeMarkers="true" stackTraceAsArray="true">
                 <KeyValuePair key="cluster.uuid" value="9fe9134b-20b0-465e-acf9-8cc09ac9053b"/>
                 <KeyValuePair key="node.id" value="${node.id}"/>
                 <KeyValuePair key="empty" value="${empty}"/>

--- a/logback-ecs-encoder/README.md
+++ b/logback-ecs-encoder/README.md
@@ -64,4 +64,4 @@ All you have to do is to use the `co.elastic.logging.logback.EcsEncoder` instead
 |-----------------|-------|-------|-----------|
 |serviceName      |String |       |Sets the `service.name` field so you can filter your logs by a particular service |
 |includeMarkers   |boolean|`false`|Log [Markers](https://www.slf4j.org/api/org/slf4j/Marker.html) as `tags` |
-|stackTraceAsArray|boolean|`false`|Serializes the `error.stack_trace` as a JSON array where each element is in a new line to improve readability. Note that this requires a slightly more complex Filebeat setup. See also https://github.com/elastic/java-ecs-logging/blob/master/README.md#TODO|
+|stackTraceAsArray|boolean|`false`|Serializes the `error.stack_trace` as a JSON array where each element is in a new line to improve readability. Note that this requires a slightly more complex [Filebeat configuration](../README.md#when-stacktraceasarray-is-enabled).|

--- a/logback-ecs-encoder/README.md
+++ b/logback-ecs-encoder/README.md
@@ -21,8 +21,6 @@ All you have to do is to use the `co.elastic.logging.logback.EcsEncoder` instead
 ```xml
 <encoder class="co.elastic.logging.logback.EcsEncoder">
     <serviceName>my-application</serviceName>
-    <!-- Log markers as tags, default: false. See also https://www.slf4j.org/api/org/slf4j/Marker.html -->
-    <includeMarkers>true</includeMarkers>
 </encoder>
 ```
 
@@ -59,3 +57,11 @@ All you have to do is to use the `co.elastic.logging.logback.EcsEncoder` instead
     </root>
 </configuration>
 ```
+
+## Encoder Parameters
+
+|Parameter name   |Type   |Default|Description|
+|-----------------|-------|-------|-----------|
+|serviceName      |String |       |Sets the `service.name` field so you can filter your logs by a particular service |
+|includeMarkers   |boolean|`false`|Log [Markers](https://www.slf4j.org/api/org/slf4j/Marker.html) as `tags` |
+|stackTraceAsArray|boolean|`false`|Serializes the `error.stack_trace` as a JSON array where each element is in a new line to improve readability. Note that this requires a slightly more complex Filebeat setup. See also https://github.com/elastic/java-ecs-logging/blob/master/README.md#TODO|

--- a/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderTest.java
+++ b/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderTest.java
@@ -48,6 +48,7 @@ class EcsEncoderTest extends AbstractEcsEncoderTest {
         ecsEncoder = new EcsEncoder();
         ecsEncoder.setServiceName("test");
         ecsEncoder.setIncludeMarkers(true);
+        ecsEncoder.setStackTraceAsArray(true);
         ecsEncoder.start();
     }
 

--- a/logback-ecs-encoder/src/test/resources/logback-config.xml
+++ b/logback-ecs-encoder/src/test/resources/logback-config.xml
@@ -4,6 +4,7 @@
         <encoder class="co.elastic.logging.logback.EcsEncoder">
             <serviceName>test</serviceName>
             <includeMarkers>true</includeMarkers>
+            <stackTraceAsArray>true</stackTraceAsArray>
         </encoder>
     </appender>
     <root level="DEBUG">


### PR DESCRIPTION
Optionally serializes stack traces as a JSON array to improve readability.

depends on elastic/ecs#562

closes #11, #25 