### PR TITLE
Fix possible NPE in log4j2 builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea
+**.iml

--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
@@ -310,11 +310,11 @@ public class EcsLayout extends AbstractStringLayout {
         @PluginBuilderAttribute("stackTraceAsArray")
         private boolean stackTraceAsArray = false;
         @PluginElement("AdditionalField")
-        private KeyValuePair[] additionalFields;
+        private KeyValuePair[] additionalFields = new KeyValuePair[] {};
         @PluginBuilderAttribute("topLevelLabels")
         private String topLevelLabels;
         @PluginBuilderAttribute("includeOrigin")
-        private boolean includeOrigin;
+        private boolean includeOrigin = false;
 
         Builder() {
             super();

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsBuilderTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsBuilderTest.java
@@ -1,0 +1,38 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.logging.log4j2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Log4j2EcsBuilderTest {
+
+    @Test
+    void testAdditionalFieldsCanBeEmptyInBuilder() {
+        EcsLayout ecsLayout = EcsLayout.newBuilder().setServiceName("test").build();
+        assertThat(ecsLayout).isNotNull();
+    }
+}


### PR DESCRIPTION
the builder no longer throws a NPE, when there are no additional fields
configured.